### PR TITLE
Include diga error code for code validation requests in response 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ docker run --env-file .env -p 5000:5000 -v /tmp/Krankenkassenverzeichnis_DiGA.xm
     Example error response
     ```json
     {
-        "timestamp": "2021-08-21T18:34:08.465+00:00",
         "status": 400,
-        "error": "Bad Request",
-        "message": "DigaCodeValidationResponseError(errorCode=REQUEST_OR_DATA_INVALID, errorText=Anfrage oder Datei ungültig)",
-        "path": "/validate/77AAAAAAAAAAAGIS"
+        "errorCode": "CODE_NOT_FOUND",
+        "errorText": "Freischaltcode / Rezeptcode nicht gefunden: 77AA AAAA AAAA ADGE",
+        "path": "/validate/77AAAAAAAAAAADGE",
+        "timestamp": "08-27-2021 06:41:07"
     }
     ```
 

--- a/src/main/kotlin/dev/gtuk/diga/AppExceptionHandler.kt
+++ b/src/main/kotlin/dev/gtuk/diga/AppExceptionHandler.kt
@@ -1,10 +1,13 @@
 package dev.gtuk.diga
 
+import dev.gtuk.diga.dtos.ValidationErrorResponse
 import dev.gtuk.diga.exceptions.BillingException
+import dev.gtuk.diga.exceptions.DigaCodeValidationException
 import dev.gtuk.diga.exceptions.TestCodesDisabledException
 import dev.gtuk.diga.exceptions.ValidationException
 import javax.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 
@@ -24,5 +27,13 @@ class AppExceptionHandler {
     @ExceptionHandler(TestCodesDisabledException::class)
     fun handleCodeValidationException(e: TestCodesDisabledException, response: HttpServletResponse) {
         response.sendError(HttpStatus.FORBIDDEN.value())
+    }
+
+    @ExceptionHandler(DigaCodeValidationException::class)
+    fun handleDigaAPICodeValidationException(e: DigaCodeValidationException, response: HttpServletResponse):
+        ResponseEntity<Any> {
+        return ResponseEntity.badRequest()
+            .body(ValidationErrorResponse(HttpStatus.BAD_REQUEST.value(), e.errorCode,
+            e.errorText, "/validate/${e.code}"))
     }
 }

--- a/src/main/kotlin/dev/gtuk/diga/Utils.kt
+++ b/src/main/kotlin/dev/gtuk/diga/Utils.kt
@@ -1,7 +1,7 @@
 package dev.gtuk.diga
 
 import com.alextherapeutics.diga.model.DigaApiTestCode
-import dev.gtuk.diga.exceptions.CodeValidationException
+import dev.gtuk.diga.exceptions.DigaCodeValidationException
 import kotlin.jvm.Throws
 
 class Utils {
@@ -11,15 +11,14 @@ class Utils {
             return code.startsWith("77")
         }
 
-        @Throws(CodeValidationException::class)
+        @Throws(DigaCodeValidationException::class)
         fun getDigaTestCode(code: String): DigaApiTestCode {
             for (digaCode in DigaApiTestCode.values()) {
                 if (digaCode.code == code) {
                     return digaCode
                 }
             }
-
-            throw CodeValidationException("$code is not a valid test code")
+            throw DigaCodeValidationException("INVALID_TEST_CODE", "$code is not a valid test code", code)
         }
     }
 }

--- a/src/main/kotlin/dev/gtuk/diga/dtos/ValidationErrorResponse.kt
+++ b/src/main/kotlin/dev/gtuk/diga/dtos/ValidationErrorResponse.kt
@@ -1,0 +1,18 @@
+package dev.gtuk.diga.dtos
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.util.Date
+
+data class ValidationErrorResponse(
+    val status: Int,
+    var errorCode: String,
+    var errorText: String,
+    val path: String
+) {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM-dd-yyyy hh:mm:ss")
+    var timestamp: Date = Date()
+
+    init {
+        this.timestamp = Date()
+    }
+}

--- a/src/main/kotlin/dev/gtuk/diga/exceptions/DigaCodeValidationException.kt
+++ b/src/main/kotlin/dev/gtuk/diga/exceptions/DigaCodeValidationException.kt
@@ -1,0 +1,3 @@
+package dev.gtuk.diga.exceptions
+
+class DigaCodeValidationException(var errorCode: String, var errorText: String, var code: String) : Exception()


### PR DESCRIPTION
Example of updated response format: 

- The `errorCode` and `errorText`  are added in lieu of `message` field
-  `error` is removed as is redundant as the http status code is present both in the header and the body. (FBM to keep it though , as it AFAICS is default behavior in `spring::boot`)
 
```json
{
    "status": 400,
    "errorCode": "CODE_NOT_FOUND",
    "errorText": "Freischaltcode / Rezeptcode nicht gefunden: 77AA AAAA AAAA ADGE",
    "path": "/validate/77AAAAAAAAAAADGE",
    "timestamp": "08-27-2021 06:41:07"
}
```

Example of current response format: 

```json
{
    "timestamp": "2021-08-22T10:35:48.992+00:00",
    "status": 400,
    "error": "Bad Request",
    "message": "DigaCodeValidationResponseError(errorCode=CODE_NOT_FOUND, errorText=Freischaltcode / Rezeptcode nicht gefunden: 77AA AAAA AAAA ADGE)",
    "path": "/validate/77AAAAAAAAAAADGE"
}
```



Addresses #10