### PR TITLE
Update Dockerfile to run Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# build stage to build the diga-api-service.jar
 FROM maven:3-jdk-11-slim as build
 
 WORKDIR /usr/src/app
@@ -6,9 +7,24 @@ COPY . /usr/src/app
 
 RUN mvn clean package
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine-slim as production
+# create production image. Use the Temurin image with Alpine Linux and Java 17
+FROM eclipse-temurin:17-alpine as production
 
-COPY --from=build /usr/src/app/target/diga-api-service-*.jar /diga-api-service.jar
+RUN mkdir /app
 
-CMD ["java", "-jar", "/diga-api-service.jar"]
+# add a new user javauser so we dont run the application as root
+RUN addgroup -S javauser && adduser -S -G javauser javauser
 
+# Copy the JAR file from the build stage into the production image
+COPY --from=build /usr/src/app/target/diga-api-service-*.jar /app/diga-api-service.jar
+
+WORKDIR /app
+
+# Set the ownership to the javauser
+RUN chown -R javauser:javauser /app
+
+# Switch to the javauser
+USER javauser
+
+# Specify the command to run your application
+CMD "java" "-jar" "diga-api-service.jar"


### PR DESCRIPTION
The latest Version of the diga-api-client [2.0.0-beta.1](https://github.com/alex-therapeutics/diga-api-client/releases/tag/2.0.0-beta.1) will break when validating or billing codes other then the test code because the dependency update of base32check-java to 0.1.0 requires Java 17.

This PR updates the production docker image to use Java 17. It uses the eclipse-temurin:17-alpine image to have a more lightweight docker image. It also adds a new user in order to avoid running the application as root.

+ Upgrade production docker image to use Java 17 to make the build compatible with the latest diga-api-client

+ in the production docker image create a new user so the application is not run as root